### PR TITLE
Preserve whitespace before and after cursor on auto-trim

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -142,32 +142,6 @@ export default class TrimWhitespace extends Plugin {
 	}
 
 	/**
-	 * Creates a version of settings that does not trim trailing text
-	 *
-	 * @param toggle Whether to enabled or disable the listener
-	 */
-	_doNotTrimTrailing(orig: TrimWhitespaceSettings): TrimWhitespaceSettings {
-		let updated: TrimWhitespaceSettings = Object.assign({}, orig);
-		updated.TrimTrailingSpaces = false;
-		updated.TrimTrailingTabs = false;
-		updated.TrimTrailingLines = false;
-		return updated;
-	}
-
-	/**
-	 * Creates a version of settings that does not trim leading text
-	 *
-	 * @param toggle Whether to enabled or disable the listener
-	 */
-	_doNotTrimLeading(orig: TrimWhitespaceSettings): TrimWhitespaceSettings {
-		let updated: TrimWhitespaceSettings = Object.assign({}, orig);
-		updated.TrimLeadingSpaces = false;
-		updated.TrimLeadingTabs = false;
-		updated.TrimLeadingLines = false;
-		return updated;
-	}
-
-	/**
 	 * Trims whitespace in selected text
 	 */
 	trimSelection(): void {
@@ -233,10 +207,18 @@ export default class TrimWhitespace extends Plugin {
 			const betweenText = input.slice(fromCursorOffset, toCursorOffset);
 			const afterText = input.slice(toCursorOffset);
 
-			const beforeTrimmed = handleTextTrim(
-				beforeText, this._doNotTrimTrailing(this.settings));
-			const afterTrimmed = handleTextTrim(
-				afterText, this._doNotTrimLeading(this.settings));
+			// Separate the before text into text and trailing whitespace
+			const beforeText0 = beforeText.trimEnd();
+			const beforeText1 = beforeText.substr(beforeText0.length);
+			// Separate the after text into leading whitespace and text
+			const afterText1 = afterText.trimStart();
+			const afterText0 = afterText.substr(
+				0, afterText.length - afterText1.length);
+
+			const beforeTrimmed =
+				handleTextTrim(beforeText0, this.settings) + beforeText1;
+			const afterTrimmed =
+				afterText0 + handleTextTrim(afterText1, this.settings);
 
 			fromNewOffset = beforeTrimmed.length;
 			toNewOffset = fromNewOffset + betweenText.length;

--- a/src/main.ts
+++ b/src/main.ts
@@ -243,6 +243,11 @@ export default class TrimWhitespace extends Plugin {
 
 			trimmed = beforeTrimmed + betweenText + afterTrimmed;
 
+			const fullyTrimmed = handleTextTrim(input, this.settings);
+			if (trimmed != fullyTrimmed) {
+				this.debouncedTrim();  // keep the debouncer cycling till done
+			}
+
 		} else {
 			// Some fuckery to get start and end cursor positions when
 			// trimming the whole document; Not ideal at all, but need to

--- a/src/utils/trimText.ts
+++ b/src/utils/trimText.ts
@@ -80,7 +80,8 @@ function _trimMultipleTabs(str: string): string {
  * @return    Trimmed text
  */
 function _trimMultipleLines(str: string): string {
-	return str.replace(/^\s+(?=(\n|\r|$))/gm, "");
+	return str.replace(/(?<=[^\r\n])[\r\n]+?(?=(?:\r?\n\r?\n|\r\r)[^\r\n])/gm,
+					   "");
 }
 
 /**


### PR DESCRIPTION
Change the behavior on auto-trim (only) so that whitespace immediately before and after the cursor is preserved, as suggested by issue #5. Any spaces, tabs and/or newlines adjacent to the cursor are preserved, even if they would normally be affected by the trimming of multiple newlines. If a selection is active, whitespace immediately before, within and after the selection is preserved.

The implementation trims the block before the cursor/selection (but doesn't trim trailing lines in that block), and trims the block after the cursor/selection (but doesn't trim leading lines in that block).

If auto-trim does not remove some whitespace because the cursor is next to it, the auto-trim stays active (keeps firing at the debounce interval) until fully trimmed.