### PR TITLE
Change/12 trim on cmd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
--
+- `CTRL/CMD + S` trims document even if Auto-Trim is disabled ([\#12](https://github.com/zlovatt/obsidian-trim-whitespace/issues/12))
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,10 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Jest test suite (thanks @velebit!)
 - Setting to preserve leading characters if part of an indented list
+- Setting to control whether `CTRL/CMD + S` trims document
 
 ### Changed
 
-- `CTRL/CMD + S` trims document even if Auto-Trim is disabled ([\#12](https://github.com/zlovatt/obsidian-trim-whitespace/issues/12))
+- Trimming via `CTRL/CMD + S` no longer requires Auto-Trim to be enabled ([\#12](https://github.com/zlovatt/obsidian-trim-whitespace/issues/12))
 
 ### Fixed
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import { TrimWhitespaceSettingTab } from "./settings";
 import handleTextTrim from "./utils/trimText";
 
 const DEFAULT_SETTINGS: TrimWhitespaceSettings = {
+	TrimOnSave: true,
+
 	AutoTrimDocument: true,
 	AutoTrimTimeout: 2.5,
 
@@ -78,7 +80,10 @@ export default class TrimWhitespace extends Plugin {
 
 		if (typeof save === "function") {
 			saveCommandDefinition.callback = () => {
-				this.trimDocument();
+				if (this.settings.TrimOnSave) {
+					this.trimDocument();
+				}
+
 				save();
 			};
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,10 +78,7 @@ export default class TrimWhitespace extends Plugin {
 
 		if (typeof save === "function") {
 			saveCommandDefinition.callback = () => {
-				if (this.settings.AutoTrimDocument) {
-					this.trimDocument();
-				}
-
+				this.trimDocument();
 				save();
 			};
 		}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,22 @@ export class TrimWhitespaceSettingTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl)
+			.setName("Trim on Manual Save")
+			.setDesc(
+				"Trim the document during manual save (CTRL / CMD + S)."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.TrimOnSave)
+					.onChange(async (value) => {
+						this.plugin.settings.TrimOnSave = value;
+						await this.plugin.saveSettings();
+
+						this.plugin._toggleListenerEvent(value);
+					});
+			});
+
+		new Setting(containerEl)
 			.setName("Auto-Trim")
 			.setDesc(
 				"Automatically trim document when modified, according to the settings below."

--- a/test/utils/trimText.test.ts
+++ b/test/utils/trimText.test.ts
@@ -34,6 +34,8 @@ voluptatem.${trailing}`;
 }
 
 const ALL_FALSE: TrimWhitespaceSettings = {
+	TrimOnSave: false,
+
 	AutoTrimDocument: false,
 	AutoTrimTimeout: 99,
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,6 @@
 interface TrimWhitespaceSettings {
+	TrimOnSave: boolean;
+
 	AutoTrimDocument: boolean;
 	AutoTrimTimeout: number;
 


### PR DESCRIPTION
Separates the ctrl/cmd+s 'trim on manual save' logic from being dependent on the 'auto trim' feature, and adds its own setting to control whether this behaviour should exist.

If auto-trim & trim on save are both off, the only way to trim the document is thus via command palette or sidebar button.