### PR TITLE
Fix/17 literals in code blocks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
--
+- "Skip Code Blocks" setting name to "Preserve Code Blocks"
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Trimming of indented lists ([\#9](https://github.com/zlovatt/obsidian-trim-whitespace/issues/9))
 - Plugin not loading on iOS (thanks @velebit!) ([\#14](https://github.com/zlovatt/obsidian-trim-whitespace/issues/14))
 - Typo in settings ([\#16](https://github.com/zlovatt/obsidian-trim-whitespace/issues/16))
+- Issue trimming code blocks containing template literals ([\#17](https://github.com/zlovatt/obsidian-trim-whitespace/issues/17))
 
 ---
 

--- a/changelog.md
+++ b/changelog.md
@@ -70,7 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Initial commit!
 
-[Unreleased]: https://github.com/zlovatt/obsidian-trim-whitespace/compare/master...develop
+[Unreleased]: https://github.com/zlovatt/obsidian-trim-whitespace/compare/main...develop
 [v0.2.2]: https://github.com/zlovatt/obsidian-trim-whitespace/compare/v0.2.1...v0.2.2
 [v0.2.1]: https://github.com/zlovatt/obsidian-trim-whitespace/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/zlovatt/obsidian-trim-whitespace/compare/v0.1.0...v0.2.0

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const DEFAULT_SETTINGS: TrimWhitespaceSettings = {
 	AutoTrimDocument: true,
 	AutoTrimTimeout: 2.5,
 
-	SkipCodeBlocks: true,
+	PreserveCodeBlocks: true,
 	PreserveIndentedLists: true,
 
 	TrimTrailingSpaces: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,13 +60,13 @@ export class TrimWhitespaceSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName("Skip Code Blocks")
-			.setDesc("Whether to ignore code blocks when trimming whitespace.")
+			.setName("Preserve Code Blocks")
+			.setDesc("Whether to preserve whitespace within code blocks.")
 			.addToggle((toggle) => {
 				toggle
-					.setValue(this.plugin.settings.SkipCodeBlocks)
+					.setValue(this.plugin.settings.PreserveCodeBlocks)
 					.onChange(async (value) => {
-						this.plugin.settings.SkipCodeBlocks = value;
+						this.plugin.settings.PreserveCodeBlocks = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/src/utils/searchReplaceTokens.ts
+++ b/src/utils/searchReplaceTokens.ts
@@ -63,7 +63,7 @@ function replaceSwappedTokens(
 ): string {
 	terms.forEach((term, ii) => {
 		const token = `{{${prefix}${ii.toString()}}}`;
-		text = text.replace(token, term);
+		text = decodeURIComponent(text.replace(token, encodeURIComponent(term)));
 	});
 
 	return text;

--- a/src/utils/trimText.ts
+++ b/src/utils/trimText.ts
@@ -185,7 +185,7 @@ export default function handleTextTrim(
 	settings: TrimWhitespaceSettings
 ): string {
 	let terms: string[] = [];
-	const skipCodeBlocks = settings.SkipCodeBlocks;
+	const skipCodeBlocks = settings.PreserveCodeBlocks;
 
 	const CODE_SWAP_PREFIX = "TRIM_WHITESPACE_REPLACE_";
 	const CODE_SWAP_REGEX = [

--- a/test/utils/trimText.test.ts
+++ b/test/utils/trimText.test.ts
@@ -37,7 +37,7 @@ const ALL_FALSE: TrimWhitespaceSettings = {
 	AutoTrimDocument: false,
 	AutoTrimTimeout: 99,
 
-	SkipCodeBlocks: false,
+	PreserveCodeBlocks: false,
 	PreserveIndentedLists: false,
 
 	TrimTrailingSpaces: false,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,7 +2,7 @@ interface TrimWhitespaceSettings {
 	AutoTrimDocument: boolean;
 	AutoTrimTimeout: number;
 
-	SkipCodeBlocks: boolean;
+	PreserveCodeBlocks: boolean;
 	PreserveIndentedLists: boolean;
 
 	TrimTrailingSpaces: boolean;


### PR DESCRIPTION
Fixes the issue of trimming code blocks / code fences that contain template literals producing wacky results.

Also renames 'skip code blocks' pref to 'preserve code blocks' for consistency