### PR TITLE
Implement alternate approach to token replace that doesn't involve decodeURIComponent

### DIFF
--- a/src/utils/searchReplaceTokens.ts
+++ b/src/utils/searchReplaceTokens.ts
@@ -63,7 +63,12 @@ function replaceSwappedTokens(
 ): string {
 	terms.forEach((term, ii) => {
 		const token = `{{${prefix}${ii.toString()}}}`;
-		text = decodeURIComponent(text.replace(token, encodeURIComponent(term)));
+
+		const termIdx = text.indexOf(token);
+		const preTerm = text.substring(0, termIdx);
+		const postTerm = text.substring(termIdx + token.length);
+
+		text = preTerm + term + postTerm;
 	});
 
 	return text;


### PR DESCRIPTION
Prior fix was fine but had the possibility to mutate the whole document with `decodeURIComponent()`, which is bad.

This approach isn't as elegant, but it works properly without needing to manually escape token literals.