### PR TITLE
Add: Option for converting non-breaking spaces

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ const DEFAULT_SETTINGS: TrimWhitespaceSettings = {
 
 	PreserveCodeBlocks: true,
 	PreserveIndentedLists: true,
+	ConvertNonBreakingSpaces: false,
 
 	TrimTrailingSpaces: true,
 	TrimLeadingSpaces: false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -85,6 +85,20 @@ export class TrimWhitespaceSettingTab extends PluginSettingTab {
 					});
 			});
 
+		new Setting(containerEl)
+			.setName("Convert non-breaking spaces")
+			.setDesc(
+				"Whether to convert non-breaking spaces to regular spaces.",
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.ConvertNonBreakingSpaces)
+					.onChange(async (value) => {
+						this.plugin.settings.ConvertNonBreakingSpaces = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
 		containerEl.createEl("h2", {
 			text: "Trimming Rules",
 		});

--- a/src/utils/trimText.ts
+++ b/src/utils/trimText.ts
@@ -130,6 +130,11 @@ function trimText(text: string, options: TrimWhitespaceSettings): string {
 	const CHAR_SPACE = " ";
 	const CHAR_TAB = "\t";
 
+	if (options.ConvertNonBreakingSpaces) {
+		// replace all instances of non-breaking spaces with regular spaces
+		trimmed = trimmed.replace(/\u00a0/g, " ");
+	}
+
 	if (options.TrimTrailingSpaces || options.TrimTrailingTabs) {
 		const trailingCharacters = [];
 

--- a/test/utils/trimText.test.ts
+++ b/test/utils/trimText.test.ts
@@ -41,6 +41,7 @@ const ALL_FALSE: TrimWhitespaceSettings = {
 
 	PreserveCodeBlocks: false,
 	PreserveIndentedLists: false,
+	ConvertNonBreakingSpaces: false,
 
 	TrimTrailingSpaces: false,
 	TrimLeadingSpaces: false,
@@ -88,6 +89,14 @@ function _trimTrailingLines(input: string): string {
 	const settings: TrimWhitespaceSettings = {
 		...ALL_FALSE,
 		TrimTrailingLines: true,
+	};
+	return handleTextTrim(input, settings);
+}
+
+function _convertNonBreakingSpaces(input: string): string {
+	const settings: TrimWhitespaceSettings = {
+		...ALL_FALSE,
+		ConvertNonBreakingSpaces: true,
 	};
 	return handleTextTrim(input, settings);
 }
@@ -651,6 +660,28 @@ describe("trimming multiple lines", () => {
 		//   does not fully remove) leading and training lines.
 		expect(_trimMultipleLines(input)).toEqual(trimmed);
 		expect(_trimMultipleLinesAndTrailingSpacesTabs(input)).toEqual(trimmed);
+	});
+});
+
+describe("conversion of non-breaking space characters", () => {
+	test("convert with no trimming", () => {
+		const input = _mkText({
+			leading: "\u00a0".repeat(5),
+			trailing: "\u00a0".repeat(5),
+			interParagraph: "\u00a0".repeat(5),
+			lineLeading: "\u00a0".repeat(5),
+			lineInternal: "\u00a0".repeat(5),
+			lineTrailing: "\u00a0".repeat(5),
+		});
+		const trimmed = _mkText({
+			leading: " ".repeat(5),
+			trailing: " ".repeat(5),
+			interParagraph: " ".repeat(5),
+			lineLeading: " ".repeat(5),
+			lineInternal: " ".repeat(5),
+			lineTrailing: " ".repeat(5),
+		});
+		expect(_convertNonBreakingSpaces(input)).toEqual(trimmed);
 	});
 });
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,6 +6,7 @@ interface TrimWhitespaceSettings {
 
 	PreserveCodeBlocks: boolean;
 	PreserveIndentedLists: boolean;
+	ConvertNonBreakingSpaces: boolean;
 
 	TrimTrailingSpaces: boolean;
 	TrimLeadingSpaces: boolean;


### PR DESCRIPTION
This PR adds the option for trimming non-breaking spaces.

This option only converts these spaces, then depending on the trimming settings (leading, trailing etc), these converted spaces will be trimmed accordingly.

- **feat(TrimWhitespaceSettings): added "ConvertNonBreakingSpaces" (default false)**
- **feat(Settings): added option to convert non-breaking spaces**
- **feat(test): added initial test for conversion of non-breaking space characters**
- **feat(trimText): added conversion of non-breaking spaces prior to trimming**
