### PR TITLE
Add: Option for preserving a set amount of lines at the end of the file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,8 @@ const DEFAULT_SETTINGS: TrimWhitespaceSettings = {
 	TrimTrailingLines: true,
 	TrimLeadingLines: false,
 	TrimMultipleLines: false,
+
+	TrailingLinesKeepMax: 0,
 };
 
 enum TrimTrigger {

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,7 +121,11 @@ export default class TrimWhitespace extends Plugin {
 	 */
 	_initializeDebouncer(delaySeconds: number): void {
 		this.debouncedTrim = debounce(
-			() => this.trimDocument(TrimTrigger.AutoTrim),
+			() => {
+				this._toggleListenerEvent(false);
+				this.trimDocument(TrimTrigger.AutoTrim);
+				this._toggleListenerEvent(true);
+			},
 			delaySeconds * 1000,
 			true,
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,10 +230,11 @@ export default class TrimWhitespace extends Plugin {
 				0,
 				fromCursorFenceIndices.start,
 			);
-			const textBeforeCursorTrimmed = handleTextTrim(
-				textBeforeCursor,
-				this.settings,
-			);
+			const textBeforeCursorTrimmed = handleTextTrim(textBeforeCursor, {
+				...this.settings,
+				// skip adding EOLs when trimming first half of text
+				TrailingLinesKeepMax: 0,
+			});
 
 			// Get the active text, where the cursor is
 			const textAtCursor = input.slice(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -126,8 +126,35 @@ export class TrimWhitespaceSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.TrimTrailingLines = value;
 						await this.plugin.saveSettings();
+
+						setTimeout(() => this.display(), 100);
 					});
 			});
+
+		this.plugin.settings.TrimTrailingLines &&
+			new Setting(containerEl)
+				.setName("Max lines to keep")
+				.setDesc("How many trailing lines to keep (e.g. POSIX uses 1)")
+				.addText((value) => {
+					value
+						.setValue(
+							this.plugin.settings.TrailingLinesKeepMax.toString(),
+						)
+						.onChange(async (value) => {
+							const textAsNumber = parseFloat(value);
+
+							if (isNaN(textAsNumber)) {
+								new Notice(
+									"Trim Whitespace: Enter a valid number!",
+								);
+								return;
+							}
+
+							this.plugin.settings.TrailingLinesKeepMax =
+								Math.max(0, textAsNumber);
+							await this.plugin.saveSettings();
+						});
+				});
 
 		containerEl.createEl("h3", {
 			text: "Leading Characters",

--- a/src/utils/trimText.ts
+++ b/src/utils/trimText.ts
@@ -1,3 +1,5 @@
+import { EOL } from "node:os";
+
 import {
 	buildTokenReplaceMap,
 	replaceSwappedTokens,
@@ -23,8 +25,11 @@ function _trimTrailingCharacters(str: string, chars: string[]): string {
  * @param str Text to trim
  * @return    Trimmed text
  */
-function _trimTrailingLines(str: string): string {
-	return str.trimEnd();
+function _trimTrailingLines(
+	str: string,
+	options: TrimWhitespaceSettings,
+): string {
+	return str.trimEnd() + EOL.repeat(options.TrailingLinesKeepMax);
 }
 
 /** Leading */
@@ -144,7 +149,7 @@ function trimText(text: string, options: TrimWhitespaceSettings): string {
 	}
 
 	if (options.TrimTrailingLines) {
-		trimmed = _trimTrailingLines(trimmed);
+		trimmed = _trimTrailingLines(trimmed, options);
 	}
 
 	if (options.TrimLeadingSpaces || options.TrimLeadingTabs) {

--- a/test/utils/trimText.test.ts
+++ b/test/utils/trimText.test.ts
@@ -176,6 +176,14 @@ function _trimMultipleLines(input: string): string {
 	};
 	return handleTextTrim(input, settings);
 }
+function _trimMultipleLinesKeep3EOLs(input: string): string {
+	const settings: TrimWhitespaceSettings = {
+		...ALL_FALSE,
+		TrimTrailingLines: true,
+		TrailingLinesKeepMax: 3,
+	};
+	return handleTextTrim(input, settings);
+}
 function _trimMultipleLinesAndTrailingSpacesTabs(input: string): string {
 	const settings: TrimWhitespaceSettings = {
 		...ALL_FALSE,
@@ -279,6 +287,15 @@ describe("trimming trailing lines", () => {
 		});
 		expect(_trimTrailingLines(input)).toEqual(trimmed);
 		expect(_trimNothing(input)).toEqual(input); // not trimmed!
+	});
+	test("trailing lines to trim, keep last 3 lines", () => {
+		const input = _mkText({
+			trailing: "\n\n\n\n\n",
+		});
+		const trimmed = _mkText({
+			trailing: "\n\n\n",
+		});
+		expect(_trimMultipleLinesKeep3EOLs(input)).toEqual(trimmed);
 	});
 	test("trailing mixed whitespace to trim", () => {
 		const input = _mkText({

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -18,6 +18,8 @@ interface TrimWhitespaceSettings {
 	TrimTrailingLines: boolean;
 	TrimLeadingLines: boolean;
 	TrimMultipleLines: boolean;
+
+	TrailingLinesKeepMax: number;
 }
 
 interface TokenReplaceMap {


### PR DESCRIPTION
This PR adds an option to preserve a set amount of lines at the end of the file.
This is particularly useful on Linux with POSIX where a file should end with a new-line.

- **feat(TrimWhitespaceSettings): added `TrailingLinesKeepMax` (defaults to 0)**
- **feat(Settings): added setting for "Max lines to keep"**
- **feat(test): added test for retaining a set amount of EOLs**
- **chore(\_trimTrailingLines): now retains user-defined amount of lines at end of file**
- **fix(trimDocument): force first half of text during auto-trim to skip adding EOLs**
- **fix(debouncedTrim): disable event listener while trimming due to auto-trim**
