### PR TITLE
Fix: Trim-on-save

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,10 +83,10 @@ export default class TrimWhitespace extends Plugin {
 		const saveCommandDefinition = (this.app as any).commands?.commands?.[
 			"editor:save-file"
 		];
-		const save = saveCommandDefinition?.callback;
+		const save = saveCommandDefinition?.checkCallback;
 
 		if (typeof save === "function") {
-			saveCommandDefinition.callback = () => {
+			saveCommandDefinition.checkCallback = () => {
 				if (this.settings.TrimOnSave) {
 					this.trimDocument(TrimTrigger.Save);
 				}


### PR DESCRIPTION
This PR fixes trim-on-save.

The Obsidian API have changed callback name for `editor:save-file` from `callback` to `checkCallback`
