### PR TITLE
Fix cursor shift

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -289,7 +289,9 @@ export default class TrimWhitespace extends Plugin {
 			return;
 		}
 
-		editor.setValue(trimmed);
+		editor.setValue(
+			trimmed + "\n".repeat(this.settings.TrailingLinesKeepMax),
+		);
 		editor.setSelection(
 			editor.offsetToPos(newFromCursorOffset),
 			editor.offsetToPos(newToCursorOffset),

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,11 +235,10 @@ export default class TrimWhitespace extends Plugin {
 				0,
 				fromCursorFenceIndices.start,
 			);
-			const textBeforeCursorTrimmed = handleTextTrim(textBeforeCursor, {
-				...this.settings,
-				// skip adding EOLs when trimming first half of text
-				TrailingLinesKeepMax: 0,
-			});
+			const textBeforeCursorTrimmed = handleTextTrim(
+				textBeforeCursor,
+				this.settings,
+			);
 
 			// Get the active text, where the cursor is
 			const textAtCursor = input.slice(

--- a/src/utils/trimText.ts
+++ b/src/utils/trimText.ts
@@ -225,7 +225,10 @@ export default function handleTextTrim(
 		terms = swapData.terms;
 	}
 
-	let trimmed = trimText(text, settings);
+	let trimmed = trimText(text, {
+		...settings,
+		TrailingLinesKeepMax: 0,
+	});
 
 	if (skipCodeBlocks) {
 		trimmed = replaceSwappedTokens(trimmed, CODE_SWAP_PREFIX, terms);

--- a/test/utils/trimText.test.ts
+++ b/test/utils/trimText.test.ts
@@ -189,9 +189,9 @@ function _trimMultipleLinesKeep3EOLs(input: string): string {
 	const settings: TrimWhitespaceSettings = {
 		...ALL_FALSE,
 		TrimTrailingLines: true,
-		TrailingLinesKeepMax: 3,
+		TrailingLinesKeepMax: 0,
 	};
-	return handleTextTrim(input, settings);
+	return handleTextTrim(input, settings) + "\n".repeat(3);
 }
 function _trimMultipleLinesAndTrailingSpacesTabs(input: string): string {
 	const settings: TrimWhitespaceSettings = {


### PR DESCRIPTION
This PR fixes the cursor shifting that happened after introducing `TrailingLinesKeepMax`.
This is done by handling all trim events as if the user has set the option to 0, then append the set amount of lines to keep after all the trimming has happened.

Fixes: #40 